### PR TITLE
Ci deploy fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
           at: *workdir_node10
       - run: echo $DEPLOY_FILE | base64 --decode > ecosystem.deploy.json
       - run: sudo npm install -g pm2
-      - run: ls -al
       - run: pm2 deploy ecosystem.deploy.json production ref $CIRCLE_TAG --force
 workflows:
   version: 2


### PR DESCRIPTION
- Fixed deployments not working because .git was not persisted into circleci workspace.
- Updated build pipeline to use node 10.14
